### PR TITLE
Bump nodeJS version to 20 (LTS)

### DIFF
--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
 		gnupg \
 	&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn.gpg \
 	&& echo "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_20.x | bash - \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
 		nodejs \


### PR DESCRIPTION
v16 is deprecated and several packages no longer build against it (core dependency installation failures).